### PR TITLE
Tune camera controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,9 +31,6 @@ export default function Home() {
     setShowEditForm(false);
   };
 
-  const handleEditLocation = () => {
-    setShowEditForm(true);
-  };
 
   const handleEditSubmit = (address: string, bufferKm: number) => {
     setCurrentAddress(address);


### PR DESCRIPTION
## Summary
- slow down deck.gl view state changes with a new handler
- reduce keyboard control step sizes
- zoom in slightly more when positioning the view
- bump default zoom
- clean up unused handler

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6840db9241cc8329ad932e06a2d89e1c