### PR TITLE
Adjust point cloud lighting

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,9 +31,6 @@ export default function Home() {
     setShowEditForm(false);
   };
 
-  const handleEditLocation = () => {
-    setShowEditForm(true);
-  };
 
   const handleEditSubmit = (address: string, bufferKm: number) => {
     setCurrentAddress(address);

--- a/src/components/visualization/FloodVisualization.tsx
+++ b/src/components/visualization/FloodVisualization.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState, useCallback } from "react";
+import Image from "next/image";
 import { PointCloudAPIService } from "./apiService";
 
 interface FloodVisualizationProps {
@@ -134,15 +135,17 @@ const FloodVisualization: React.FC<FloodVisualizationProps> = ({
         {/* Image Display */}
         {imageData && !isLoading && !error && (
           <div className="h-full w-full flex items-center justify-center p-4">
-            <img
+            <Image
               src={imageData}
               alt="Flood risk visualization"
+              width={800}
+              height={600}
               className="max-w-full max-h-full object-contain border-2 border-gray-600"
               style={{
                 imageRendering: "pixelated", // Preserve sharp edges for flood data
               }}
               onLoad={(e) => {
-                const img = e.target as HTMLImageElement;
+                const img = e.currentTarget;
                 console.log(
                   `Flood image dimensions: ${img.naturalWidth}x${img.naturalHeight}`
                 );

--- a/src/components/visualization/PointCloudVisualization.tsx
+++ b/src/components/visualization/PointCloudVisualization.tsx
@@ -209,10 +209,11 @@ const PointCloudVisualization: React.FC<PointCloudVisualizationProps> = ({
       coordinateSystem: 1, // COORDINATE_SYSTEM.LNGLAT
       modelMatrix: null,
       material: {
-        ambient: 0.35,
-        diffuse: 0.6,
-        shininess: 32,
-        specularColor: [255, 255, 255],
+        // Slightly softer lighting to avoid overly bright highlights
+        ambient: 0.3,
+        diffuse: 0.4,
+        shininess: 16,
+        specularColor: [180, 180, 180],
       },
       parameters: {
         depthTest: true,

--- a/src/components/visualization/README.md
+++ b/src/components/visualization/README.md
@@ -54,7 +54,8 @@ import { PointCloudVisualization } from "../components/visualization";
 - **Advanced Camera Controls**: Interactive controls for zoom, pitch, bearing with preset views
 - **Enhanced 3D Navigation**: Smooth panning, rotation, and zooming with inertia
 - **Keyboard Navigation**: Full keyboard support for camera movement and control
-- **Better Point Cloud Rendering**: Improved depth testing and material properties for realistic 3D visualization
+ - **Better Point Cloud Rendering**: Improved depth testing and material properties for realistic 3D visualization
+ - **Softer Lighting**: Reduced specular highlights for a less harsh light source
 
 ## Camera Controls
 


### PR DESCRIPTION
## Summary
- reduce diffuse/specular values for a dimmer look
- mention softer lighting in the visualization docs
- remove unused `handleEditLocation` function
- replace `<img>` with Next.js `<Image>` for flood visualization

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6840db5e2e98832993642ae69bb557a7