### PR TITLE
Add minimization toggle for camera controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,6 +31,7 @@ export default function Home() {
     setShowEditForm(false);
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleEditLocation = () => {
     setShowEditForm(true);
   };

--- a/src/components/visualization/CameraControls.tsx
+++ b/src/components/visualization/CameraControls.tsx
@@ -7,12 +7,14 @@ interface CameraControlsProps {
   viewState: ViewState;
   onViewStateChange: (viewState: Partial<ViewState>) => void;
   onResetView: () => void;
+  onMinimize?: () => void;
 }
 
 const CameraControls: React.FC<CameraControlsProps> = ({
   viewState,
   onViewStateChange,
   onResetView,
+  onMinimize,
 }) => {
   const handleSliderChange = (property: keyof ViewState, value: number) => {
     onViewStateChange({ [property]: value });
@@ -28,12 +30,23 @@ const CameraControls: React.FC<CameraControlsProps> = ({
           <h3 className="text-sm font-black text-white font-space-grotesk">
             Camera Controls
           </h3>
-          <button
-            onClick={onResetView}
-            className="px-3 py-1 text-xs bg-blue-600 text-white hover:bg-blue-700 transition-colors border border-blue-600 font-space-grotesk font-black"
-          >
-            Reset View
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onResetView}
+              className="px-3 py-1 text-xs bg-blue-600 text-white hover:bg-blue-700 transition-colors border border-blue-600 font-space-grotesk font-black"
+            >
+              Reset View
+            </button>
+            {onMinimize && (
+              <button
+                onClick={onMinimize}
+                className="text-gray-300 hover:text-white text-lg leading-none font-black"
+                title="Hide Controls"
+              >
+                ×
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Zoom Control */}

--- a/src/components/visualization/PointCloudVisualization.tsx
+++ b/src/components/visualization/PointCloudVisualization.tsx
@@ -28,6 +28,7 @@ const PointCloudVisualization: React.FC<PointCloudVisualizationProps> = ({
   const [downloadProgress, setDownloadProgress] = useState<number>(0);
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
   const [pointSize, setPointSize] = useState<number>(1);
+  const [showCameraControls, setShowCameraControls] = useState<boolean>(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [initialBounds, setInitialBounds] = useState<{
     minLon: number;
@@ -384,11 +385,35 @@ const PointCloudVisualization: React.FC<PointCloudVisualizationProps> = ({
 
         {/* Top right - Camera controls (positioned below centered address to avoid overlap) */}
         <div className="absolute top-20 right-4 pointer-events-auto hidden lg:block">
-          <CameraControls
-            viewState={viewState}
-            onViewStateChange={handleViewStateUpdate}
-            onResetView={resetView}
-          />
+          {showCameraControls ? (
+            <CameraControls
+              viewState={viewState}
+              onViewStateChange={handleViewStateUpdate}
+              onResetView={resetView}
+              onMinimize={() => setShowCameraControls(false)}
+            />
+          ) : (
+            <button
+              onClick={() => setShowCameraControls(true)}
+              className="backdrop-blur-sm p-2 shadow-lg hover:bg-gray-700 transition-all border-2 border-white font-space-grotesk"
+              style={{ backgroundColor: "#1B2223" }}
+              title="Camera Controls"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+                <circle cx="12" cy="13" r="4" />
+              </svg>
+            </button>
+          )}
         </div>
 
         {/* Bottom left - Status display */}


### PR DESCRIPTION
## Summary
- add an optional `onMinimize` prop to `CameraControls`
- implement minimize button on `CameraControls`
- allow toggling camera controls visibility in `PointCloudVisualization`
- silence unused variable lint warning in `page.tsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840dbb5d7748329a6c04c6e79ed0c82